### PR TITLE
Allow Proxy to inherit methods

### DIFF
--- a/src/main/java/com/lmax/tool/disruptor/bytecode/ArgumentHolderHelper.java
+++ b/src/main/java/com/lmax/tool/disruptor/bytecode/ArgumentHolderHelper.java
@@ -27,7 +27,7 @@ final class ArgumentHolderHelper
 {
     public Map<Class<?>, Integer> getParameterTypeCounts(final Class<?> type)
     {
-        final Method[] methods = type.getDeclaredMethods();
+        final Method[] methods = type.getMethods();
         final Map<Class<?>, Integer> parameterTypeCounts = new HashMap<Class<?>, Integer>();
         for (Method method : methods)
         {

--- a/src/main/java/com/lmax/tool/disruptor/bytecode/GeneratedRingBufferProxyGenerator.java
+++ b/src/main/java/com/lmax/tool/disruptor/bytecode/GeneratedRingBufferProxyGenerator.java
@@ -143,7 +143,7 @@ public final class GeneratedRingBufferProxyGenerator implements RingBufferProxyG
         createFields(methodToInvokerMap, ctClass);
         createConstructor(ctClass);
 
-        for (final Method method : proxyInterface.getDeclaredMethods())
+        for (final Method method : proxyInterface.getMethods())
         {
             createRingBufferPublisherMethod(ctClass, method, methodToInvokerMap.get(method), overflowStrategy, argumentHolderGenerator);
         }
@@ -364,7 +364,7 @@ public final class GeneratedRingBufferProxyGenerator implements RingBufferProxyG
     {
         final Map<Method, Invoker> methodToInvokerMap = new HashMap<Method, Invoker>();
 
-        final Method[] declaredMethods = proxyInterface.getDeclaredMethods();
+        final Method[] declaredMethods = proxyInterface.getMethods();
 
         for (Method declaredMethod : declaredMethods)
         {

--- a/src/main/java/com/lmax/tool/disruptor/reflect/ReflectiveRingBufferProxyGenerator.java
+++ b/src/main/java/com/lmax/tool/disruptor/reflect/ReflectiveRingBufferProxyGenerator.java
@@ -121,7 +121,7 @@ public final class ReflectiveRingBufferProxyGenerator implements RingBufferProxy
     private static <T> Map<Method, Invoker> createMethodToInvokerMap(final Class<T> proxyInterface)
     {
         final Map<Method, Invoker> methodToInvokerMap = new ConcurrentHashMap<Method, Invoker>();
-        final Method[] declaredMethods = proxyInterface.getDeclaredMethods();
+        final Method[] declaredMethods = proxyInterface.getMethods();
 
         for (final Method declaredMethod : declaredMethods)
         {

--- a/src/test/java/com/lmax/tool/disruptor/AbstractRingBufferProxyGeneratorTest.java
+++ b/src/test/java/com/lmax/tool/disruptor/AbstractRingBufferProxyGeneratorTest.java
@@ -92,6 +92,7 @@ public abstract class AbstractRingBufferProxyGeneratorTest
                 OverflowStrategy.DROP, new StubImplementationForInterface());
     }
 
+    @SuppressWarnings("StatementWithEmptyBody")
     @Test
     public void shouldProxy()
     {
@@ -129,6 +130,7 @@ public abstract class AbstractRingBufferProxyGeneratorTest
         assertThat(implementation.getLastDoubleArray(), is(equalTo(new Double[] {(double) 2})));
     }
 
+    @SuppressWarnings("StatementWithEmptyBody")
     @Test
     public void shouldProxyMultipleImplementations()
     {


### PR DESCRIPTION
Currently, a DelegatingProxy interface can extend other interfaces, but must redefine these inherited methods for the code generator to pick the methods up. This feels like an artificial limitation so this pull should fix that up. I've provided a unit-test which documents the extra-behaviour. 

This change ended up being mostly about changing the reflective use of getDeclaredMethods to getMethods, so it's nice and small. 