### PR TITLE
Add GitHub Actions for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: Java CI with Gradle
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java: [ 11 ]
+    name: Java ${{ matrix.java }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up java
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java }}
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+      - name: Build with Gradle
+        run: ./gradlew build

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -1,0 +1,10 @@
+name: "Validate Gradle Wrapper"
+on: [push, pull_request]
+
+jobs:
+  validation:
+    name: "Validation"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: gradle/wrapper-validation-action@v1

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
-disruptor-proxy       [![Build Status](https://travis-ci.org/LMAX-Exchange/disruptor-proxy.svg)](https://travis-ci.org/LMAX-Exchange/disruptor-proxy)
-===============
+# disruptor-proxy
+
+![Java CI with Gradle](https://github.com/LMAX-Exchange/disruptor-proxy/workflows/Java%20CI%20with%20Gradle/badge.svg)
+[![License](https://img.shields.io/github/license/LMAX-Exchange/disruptor-proxy)](https://github.com/LMAX-Exchange/disruptor-proxy/blob/master/LICENCE.txt)
 
 The disruptor-proxy is a tool for creating thread-safe proxies to your existing business code.
 
@@ -11,17 +13,14 @@ This in turn allows users to exploit the
 [single-writer principle](http://mechanical-sympathy.blogspot.co.uk/2011/09/single-writer-principle.html)
 for maximum straight-line performance.
 
-
-
 ![implementation diagram](https://raw.githubusercontent.com/LMAX-Exchange/disruptor-proxy/master/doc/DisruptorProxy.jpg)
 
-Maintainer
-----------
+## Maintainer
 
-[Mark Price](https://github.com/epickrram)
 
-Examples
---------
+LMAX Development Team
+
+## Examples
 
 ```java
 
@@ -78,15 +77,13 @@ disruptor.start();
 ```
 
 
-GeneratorType
--------------
+## GeneratorType
 
 * `GeneratorType.JDK_REFLECTION` - uses `java.lang.reflect.Proxy` to generate a dynamic proxy that will add events to the RingBuffer. Use this for minimal dependencies.
 * `GeneratorType.BYTECODE_GENERATION` - uses Javassist to generate classes that will add events to the RingBuffer. Use this for maximum performance.
 
 
-Dependencies
-------------
+## Dependencies
 
 Minimal dependency is the Disruptor JAR. 
 


### PR DESCRIPTION
Since the current CI tool this project uses, Travis CI is forcing users on to their paid-account domain using GitHub Actions for CI seems like a fair thing to do. This fixes #18 which I raised earlier with more information about the changes happening to Travis CI.

Also updated the Readme to have GitHub Action badge (and a few other updates thrown in for luck).