### PR TITLE
Move generated class packages to enable java 21 support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ repositories {
 dependencies {
     testImplementation 'junit:junit:4.5'
     testImplementation 'org.hamcrest:hamcrest-core:1.3'
-    implementation 'org.javassist:javassist:3.19.0-GA'
+    implementation 'org.javassist:javassist:3.30.2-GA'
     implementation 'com.lmax:disruptor:3.3.0'
 }
 

--- a/src/main/java/com/lmax/tool/disruptor/bytecode/ArgumentHolderGenerator.java
+++ b/src/main/java/com/lmax/tool/disruptor/bytecode/ArgumentHolderGenerator.java
@@ -50,7 +50,7 @@ final class ArgumentHolderGenerator
 
     public void createArgumentHolderClass(final Class<?> proxyInterface)
     {
-        final CtClass ctClass = makeClass(classPool, "_argumentHolder_" + proxyInterface.getSimpleName() + "_" + getUniqueIdentifier());
+        final CtClass ctClass = makeClass(classPool, "com.lmax.tool.disruptor.bytecode._argumentHolder_" + proxyInterface.getSimpleName() + "_" + getUniqueIdentifier());
 
         parameterTypeCounts = helper.getParameterTypeCounts(proxyInterface);
         createFields(ctClass);
@@ -61,7 +61,7 @@ final class ArgumentHolderGenerator
         {
             ctClass.addConstructor(CtNewConstructor.defaultConstructor(ctClass));
             makePublicFinal(ctClass);
-            generatedClass = ctClass.toClass();
+            generatedClass = ctClass.toClass(ArgumentHolderGenerator.class);
         }
         catch (CannotCompileException e)
         {

--- a/src/main/java/com/lmax/tool/disruptor/bytecode/GeneratedRingBufferProxyGenerator.java
+++ b/src/main/java/com/lmax/tool/disruptor/bytecode/GeneratedRingBufferProxyGenerator.java
@@ -158,7 +158,7 @@ public final class GeneratedRingBufferProxyGenerator implements RingBufferProxyG
                                 final Map<Method, Invoker> methodToInvokerMap, final OverflowStrategy overflowStrategy,
                                 final ArgumentHolderGenerator argumentHolderGenerator)
     {
-        final CtClass ctClass = makeClass(classPool, "_proxy" + proxyInterface.getSimpleName() + '_' +
+        final CtClass ctClass = makeClass(classPool, "com.lmax.tool.disruptor.bytecode._proxy" + proxyInterface.getSimpleName() + '_' +
                 getUniqueIdentifier());
 
         addInterface(ctClass, proxyInterface, classPool);
@@ -179,7 +179,7 @@ public final class GeneratedRingBufferProxyGenerator implements RingBufferProxyG
     {
         try
         {
-            return instantiate(ctClass.toClass(), new Class[]{RingBuffer.class, DropListener.class,
+            return instantiate(ctClass.toClass(GeneratedRingBufferProxyGenerator.class), new Class[]{RingBuffer.class, DropListener.class,
                     MessagePublicationListener.class}, ringBuffer, dropListener, messagePublicationListener);
         }
         catch (CannotCompileException e)
@@ -250,7 +250,7 @@ public final class GeneratedRingBufferProxyGenerator implements RingBufferProxyG
             final Invoker invoker = methodToInvokerMap.get(method);
 
             createField(ctClass, "private final " + invoker.getClass().getName() + " _" +
-                    invoker.getClass().getName() + " = new " + invoker.getClass().getName() + "();");
+                    invoker.getClass().getName().replace(".", "_") + " = new " + invoker.getClass().getName() + "();");
         }
     }
 
@@ -303,7 +303,7 @@ public final class GeneratedRingBufferProxyGenerator implements RingBufferProxyG
             methodSrc.append("holder.").append(holderField).append(" = ").append((char) ('a' + i)).append(";");
         }
 
-        methodSrc.append("proxyMethodInvocation.setInvoker(_").append(invoker.getClass().getName()).
+        methodSrc.append("proxyMethodInvocation.setInvoker(_").append(invoker.getClass().getName().replace(".", "_")).
                 append(");\n").
                 append("}\n").
                 append("catch(Throwable t){t.printStackTrace();}\n").
@@ -332,7 +332,7 @@ public final class GeneratedRingBufferProxyGenerator implements RingBufferProxyG
     @SuppressWarnings("unchecked")
     private <T> Invoker generateInvoker(final Class<T> proxyInterface, final Method method, final ArgumentHolderGenerator argumentHolderGenerator)
     {
-        final StringBuilder invokerClassName = new StringBuilder("_invoker").append(proxyInterface.getSimpleName()).
+        final StringBuilder invokerClassName = new StringBuilder("com.lmax.tool.disruptor.bytecode._invoker").append(proxyInterface.getSimpleName()).
                 append(method.getName()).append('_').append(getUniqueIdentifier());
 
         final Class<?>[] parameterTypes = method.getParameterTypes();
@@ -378,7 +378,7 @@ public final class GeneratedRingBufferProxyGenerator implements RingBufferProxyG
         {
             ctClass.addMethod(CtMethod.make(methodSrc.toString(), ctClass));
             ctClass.addConstructor(CtNewConstructor.defaultConstructor(ctClass));
-            final Class generatedClass = ctClass.toClass();
+            final Class generatedClass = ctClass.toClass(GeneratedRingBufferProxyGenerator.class);
             return (Invoker) generatedClass.newInstance();
         }
         catch (CannotCompileException e)


### PR DESCRIPTION
Java 21 doesn't like us defining classes outside of the current package, it also requires a "neighbour" class. These commits upgrade javassist for the new apis needed for the neighbour class and move the generated classes into our own package